### PR TITLE
Changed node to command_node

### DIFF
--- a/rexe.py
+++ b/rexe.py
@@ -149,7 +149,7 @@ class Rexe:
                         self.execute_command(node, command)
             else:
                 for command in commands_list:
-                    self.execute_command(node, command)
+                    self.execute_command(command_node, command)
 
 if __name__ == "__main__":
     exit_flag = False


### PR DESCRIPTION
Not working for not defined alls and allp servers

Error:
node getting referenced before getting defined.

Hence changed node to command_node.
Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>